### PR TITLE
Residual operation improve

### DIFF
--- a/codewordmask.c
+++ b/codewordmask.c
@@ -61,7 +61,7 @@ static u_int8_t alignment_patterns[40][8] = {
 int get_codeword_mask(unsigned int size, struct bit_matrix* *mask) {
     if (size < 21
         || size > 177
-        || (size % 4) != 1) {
+        || (size & 3) != 1) {
             return DECODING_ERROR;
     }
 


### PR DESCRIPTION
Bit operation only needs an instruction cycle to complete, and most of the C compiler "%" operation is to call subroutines to complete, the code is long, slow execution speed. In general, as long as the remainder of 2n square is sought, the method of bit operation can be used instead.